### PR TITLE
Webpack devServer options updated

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -14,6 +14,12 @@ export default {
     path: path.join(__dirname, "/playground/public/assets"),
   },
   mode: "development",
+  devServer: {
+    headers: {
+      'Cross-Origin-Embedder-Policy': 'require-corp',
+      'Cross-Origin-Opener-Policy': 'same-origin',
+    },
+  },
   module: {
     rules: [
       {


### PR DESCRIPTION
Updated the devServer option in the webpack config file in order to allow for the use of the SharedBuffer. This was needed to implement the stop block in [BXC-113](https://linear.app/bxcoding/issue/BXC-113/implement-stop-block)