### PR TITLE
fix: removed reference to legacy activeSprite

### DIFF
--- a/src/components/provider/PyatchProvider.jsx
+++ b/src/components/provider/PyatchProvider.jsx
@@ -232,7 +232,7 @@ const PyatchProvider = props => {
 
   const handleAddCostumesToActiveTarget = (costumes, fromCostumeLibrary) => {
     console.warn(costumes);
-    handleNewCostume(costumes, fromCostumeLibrary, 'target' + activeSprite);
+    handleNewCostume(costumes, fromCostumeLibrary, editingTargetId);
   }
 
   addToGlobalState({ 


### PR DESCRIPTION
resolves [BXC-146](https://linear.app/bxcoding/issue/BXC-146/add-existing-costume-reference-error)