### PR TITLE
Elliotbroe/bxc-192 when key pressed event not firing on arrow keys

### DIFF
--- a/src/components/PyatchTargetEditor.jsx
+++ b/src/components/PyatchTargetEditor.jsx
@@ -60,7 +60,6 @@ function ThreadEditor(props) {
     }
 
     const handleCodeChange = (newValue) => {
-        console.warn("Code changed", newValue);
         setThreadsText({...threadsText, [thread.id]: newValue});
         setSavedThreads({...savedThreads, [thread.id]: false});
         setChangesSinceLastSave(true);


### PR DESCRIPTION
Resolves [BXC-192](https://linear.app/bxcoding/issue/BXC-192/when-key-pressed-event-not-firing-on-arrow-keys)