### PR TITLE
elliotbroe/bxc-196-saving-locally-does-not-save-unsaved-threads

### DIFF
--- a/src/components/PatchTopBar.jsx
+++ b/src/components/PatchTopBar.jsx
@@ -73,7 +73,7 @@ export function PatchFileName() {
 }
 
 export function PatchFileButton() {
-  const { saveToLocalStorage, loadFromLocalStorage, downloadProject, loadSerializedProject, changesSinceLastSave } = useContext(pyatchContext);
+  const { saveToLocalStorage, loadFromLocalStorage, downloadProject, loadSerializedProject, changesSinceLastSave, saveAllThreads } = useContext(pyatchContext);
   
   const [anchorEl, setAnchorEl] = useState(null);
   const open = Boolean(anchorEl);
@@ -84,10 +84,10 @@ export function PatchFileButton() {
 
   const handleClose = (event) => {
     setAnchorEl(null);
-    console.log(event.currentTarget.id);
-  };
+  };  
 
   const handleSaveNow = async (event) => {
+    await saveAllThreads();
     // idk if awaiting this is bad but it is unnecessary.
     saveToLocalStorage();
   };

--- a/src/components/provider/PyatchProvider.jsx
+++ b/src/components/provider/PyatchProvider.jsx
@@ -455,12 +455,14 @@ const PyatchProvider = props => {
   }
 
   const saveAllThreads = async () => {
-   await Object.keys(threadsText).forEach(async threadId => {
+    const threadSavePromises = [];
+   Object.keys(threadsText).forEach(async threadId => {
       if (!savedThreads[threadId]) {
-        await pyatchVM.getThreadById(threadId).updateThreadScript(threadsText[threadId]);
+        threadSavePromises.push(pyatchVM.getThreadById(threadId).updateThreadScript(threadsText[threadId]));
         setSavedThreads({ ...savedThreads, [threadId]: true });
       }
     });
+    await Promise.all(threadSavePromises);
   }
   
   const downloadProject = async () => {


### PR DESCRIPTION
The save all threads helper function was incorrectly awaited.

Resolves [BXC-196](https://linear.app/bxcoding/issue/BXC-196/saving-locally-does-not-save-unsaved-threads)